### PR TITLE
Add support for pulling SARIF files from GHES

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 dependencies {
 //    implementation(libs.annotations)
     implementation("com.contrastsecurity:java-sarif:2.0")
+    testImplementation("org.assertj:assertj-core:3.24.2")
 }
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
@@ -10,10 +10,15 @@ import javax.swing.JPanel
 class SettingComponent {
     private var myMainPanel: JPanel? = null
     private val ghTokenText = JBTextField()
+    private val ghesHostnameText = JBTextField()
+    private val ghesTokenText = JBTextField()
 
     init {
         myMainPanel = FormBuilder.createFormBuilder()
                 .addLabeledComponent(JBLabel("GitHub PAT "), ghTokenText, 1, false)
+                .addSeparator()
+                .addLabeledComponent(JBLabel("GHE Hostname"), ghesHostnameText, 2, false)
+                .addLabeledComponent(JBLabel("GHE Token"), ghesTokenText, 3, false)
                 .addComponentFillVertically(JPanel(), 0)
                 .getPanel()
     }
@@ -33,5 +38,21 @@ class SettingComponent {
 
     fun setGhTokenText(newText: String) {
         ghTokenText.setText(newText)
+    }
+
+    fun getGhesHostnameText(): String {
+        return ghesHostnameText.getText()
+    }
+
+    fun getGhesTokenText(): String {
+        return ghesTokenText.getText()
+    }
+
+    fun setGhesHostnameText(newText: String) {
+        ghesHostnameText.setText(newText)
+    }
+
+    fun setGhesTokenText(newText: String) {
+        ghesTokenText.setText(newText)
     }
 }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/Settings.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/Settings.kt
@@ -7,7 +7,7 @@ import com.intellij.util.messages.Topic
 import javax.swing.JComponent
 
 
-class Settings: Configurable, Configurable.NoScroll, Disposable {
+class Settings : Configurable, Configurable.NoScroll, Disposable {
     private var mySettingsComponent: SettingComponent? = null
 
     interface SettingsSavedListener {
@@ -25,15 +25,23 @@ class Settings: Configurable, Configurable.NoScroll, Disposable {
     override fun createComponent(): JComponent {
         mySettingsComponent = SettingComponent()
         mySettingsComponent!!.setGhTokenText(SettingsState.instance.state.pat)
+        mySettingsComponent!!.setGhesHostnameText(SettingsState.instance.state.ghesHostname)
+        mySettingsComponent!!.setGhesTokenText(SettingsState.instance.state.ghesPat)
         return mySettingsComponent!!.getPanel()
     }
 
     override fun isModified(): Boolean =
-            !mySettingsComponent!!.getGhTokenText().equals(SettingsState.instance.state.pat)
+            listOf(
+                    !mySettingsComponent!!.getGhTokenText().equals(SettingsState.instance.state.pat),
+                    !mySettingsComponent!!.getGhesHostnameText().equals(SettingsState.instance.state.ghesHostname),
+                    !mySettingsComponent!!.getGhesTokenText().equals(SettingsState.instance.state.ghesPat),
+            ).any()
 
     override fun apply() {
         val settings: SettingsState = SettingsState.instance
         settings.state.pat = mySettingsComponent!!.getGhTokenText()
+        settings.state.ghesHostname = mySettingsComponent!!.getGhesHostnameText()
+        settings.state.ghesPat = mySettingsComponent!!.getGhesTokenText()
 
         ApplicationManager.getApplication().messageBus.syncPublisher(SETTINGS_SAVED_TOPIC).settingsSaved()
 
@@ -41,6 +49,8 @@ class Settings: Configurable, Configurable.NoScroll, Disposable {
 
     override fun reset() {
         mySettingsComponent?.setGhTokenText(SettingsState.instance.state.pat)
+        mySettingsComponent?.setGhesHostnameText(SettingsState.instance.state.ghesHostname)
+        mySettingsComponent?.setGhesTokenText(SettingsState.instance.state.ghesPat)
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingsState.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingsState.kt
@@ -32,6 +32,8 @@ open class SettingsState : PersistentStateComponent<SettingsState.PluginState> {
     // the POKO class that always keeps our state
     class PluginState {
         var pat = "Insert your GitHub PAT here"
+        var ghesHostname = "Insert your GitHub Enterprise Server hostname here"
+        var ghesPat = "Insert your GitHub Enterprise Server PAT here"
     }
 
 }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/exception/SarifViewerException.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/exception/SarifViewerException.kt
@@ -5,7 +5,7 @@ class SarifViewerException(val code: Int, override val message: String): Excepti
         val INVALID_PAT = SarifViewerException(1, "Invalid GitHub PAT")
         val UNAUTHORIZED = SarifViewerException(2, "Unauthorized: \nthe token provided doesn't have the authorization to access the current repository\nor the current branch haven't been pushed")
         val INVALID_ANALYSIS_ID = SarifViewerException(3, "Invalid analysis ID")
-        val INVALID_REPOSITORY = SarifViewerException(4, "Invalid repository")
+        val INVALID_REPOSITORY = SarifViewerException(4, "Invalid repository or no analyses available")
         val INVALID_BRANCH = SarifViewerException(5, "Invalid branch")
         val INVALID_ANALYSIS = SarifViewerException(6, "Invalid analysis")
     }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/utils/GitHubInstance.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/utils/GitHubInstance.kt
@@ -1,0 +1,42 @@
+package com.github.adrienpessu.sarifviewer.utils
+
+import org.jetbrains.annotations.VisibleForTesting
+import java.net.URL
+
+data class GitHubInstance(val hostname: String, val apiBase: String = "https://$hostname/api/v3") {
+    // Keep this out of the constructor so that it doesn't accidentally end up in a toString() output
+    var token: String = ""
+
+    fun extractRepoNwo(remoteUrl: String?): String? {
+        if (remoteUrl?.startsWith("https") == true) {
+            return URL(remoteUrl).path.replace(Regex("^/"), "").replace(Regex(".git$"), "")
+        } else if (remoteUrl?.startsWith("git@") == true) {
+            return remoteUrl.replace(Regex("^git@$hostname:"), "").replace(Regex(".git$"), "")
+        }
+        return null
+    }
+
+    companion object {
+        val DOT_COM: GitHubInstance = GitHubInstance("github.com", "https://api.github.com")
+
+        @VisibleForTesting
+        fun extractHostname(remoteUrl: String?): String? {
+            if (remoteUrl?.startsWith("https") == true) {
+                return URL(remoteUrl).host
+            } else if (remoteUrl?.startsWith("git@") == true) {
+                return remoteUrl.substringAfter("git@").substringBefore(":")
+            }
+            return null
+        }
+
+        fun fromRemoteUrl(remoteUrl: String): GitHubInstance? {
+            val hostname = extractHostname(remoteUrl)
+            if (hostname == DOT_COM.hostname) {
+                return DOT_COM
+            } else if (!hostname.isNullOrEmpty()){
+                return GitHubInstance(hostname)
+            }
+            return null
+        }
+    }
+}

--- a/src/test/kotlin/com/github/adrienpessu/sarifviewer/util/GithubInstanceTest.kt
+++ b/src/test/kotlin/com/github/adrienpessu/sarifviewer/util/GithubInstanceTest.kt
@@ -1,0 +1,45 @@
+package com.github.adrienpessu.sarifviewer.util
+
+import com.github.adrienpessu.sarifviewer.utils.GitHubInstance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GithubInstanceTest {
+    companion object {
+        const val DOTCOM_GIT_URL = "git@github.com:adrienpessu/SARIF-viewer.git"
+        const val DOTCOM_HTTPS_URL = "https://github.com/adrienpessu/SARIF-viewer.git"
+        const val GHES_GIT_URL = "git@github.private.domain:adrienpessu/SARIF-viewer.git"
+        const val GHES_HTTPS_URL = "https://github.private.domain/adrienpessu/SARIF-viewer.git"
+
+        const val DOTCOM_HOSTNAME = "github.com"
+        const val GHES_HOSTNAME = "github.private.domain"
+        const val REPO_NWO = "adrienpessu/SARIF-viewer"
+
+        val DOTCOM_INSTANCE = GitHubInstance.DOT_COM
+        val GHES_INSTANCE = GitHubInstance(GHES_HOSTNAME)
+    }
+
+    @Test
+    fun testExtractHostnameFromSsh() {
+        assertThat(GitHubInstance.extractHostname(DOTCOM_GIT_URL)).isEqualTo(DOTCOM_HOSTNAME)
+        assertThat(GitHubInstance.extractHostname(GHES_GIT_URL)).isEqualTo(GHES_HOSTNAME)
+    }
+
+    @Test
+    fun testExtractHostnameFromHttps() {
+        assertThat(GitHubInstance.extractHostname(DOTCOM_HTTPS_URL)).isEqualTo(DOTCOM_HOSTNAME)
+        assertThat(GitHubInstance.extractHostname(GHES_HTTPS_URL)).isEqualTo(GHES_HOSTNAME)
+    }
+
+    @Test
+    fun testExtractRepoNwoFromSsh() {
+        assertThat(DOTCOM_INSTANCE.extractRepoNwo(DOTCOM_GIT_URL)).isEqualTo(REPO_NWO)
+        assertThat(GHES_INSTANCE.extractRepoNwo(GHES_GIT_URL)).isEqualTo(REPO_NWO)
+    }
+
+    @Test
+    fun testExtractRepoNwoFromHttps() {
+        assertThat(DOTCOM_INSTANCE.extractRepoNwo(DOTCOM_HTTPS_URL)).isEqualTo(REPO_NWO)
+        assertThat(GHES_INSTANCE.extractRepoNwo(GHES_HTTPS_URL)).isEqualTo(REPO_NWO)
+    }
+}


### PR DESCRIPTION
Add a couple config fields that allow users to specify an on-prem instance of GitHub Enterprise Server to pull SARIF files from.

If a local repository has multiple configured remotes, this change will filter the list of remotes down to GitHub.com and the configured GHES host, then pick the first eligible remote returned by `repository.remotes`.

This change also includes a minor bug fix for branch names that contain slashes (e.g. `feature/ghes-support` or `bugfix/ghes-support`).