### PR TITLE
22 add a loading image to make the user understand its loading

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -80,7 +81,10 @@ class SarifViewerWindowFactory : ToolWindowFactory {
         private val steps = JEditorPane()
         private val errorField = JLabel("Error message here ")
         private val errorToolbar = JToolBar("", JToolBar.HORIZONTAL)
+        private val loadingPanel = JPanel()
         private var sarifGitHubRef = ""
+        private var loading = false
+        private var disableComboBoxEvent = false
 
         fun getContent() = JBPanel<JBPanel<*>>().apply {
 
@@ -91,25 +95,31 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
             messageBus.connect().subscribe(Settings.SETTINGS_SAVED_TOPIC, object : Settings.SettingsSavedListener {
                 override fun settingsSaved() {
+                    val repository = GitRepositoryManager.getInstance(project).repositories.firstOrNull()
                     if (!localMode) {
                         clearJSplitPane()
-
-                        val repository = GitRepositoryManager.getInstance(project).repositories.firstOrNull()
                         if (repository != null) {
+                            toggleLoading()
                             loadDataAndUI(repository)
-                        } else {
-                            add(JLabel("No Git repository found"))
+                            toggleLoading()
                         }
                     }
                 }
             })
 
+            DumbService.getInstance(project).runWhenSmart {
+                // Your code here. This block will be executed after the indexing is finished.
+            }
+
             messageBus.connect().subscribe(GitRepository.GIT_REPO_CHANGE, object : GitRepositoryChangeListener {
                 override fun repositoryChanged(repository: GitRepository) {
                     if (!localMode) {
                         clearJSplitPane()
-                        loadDataAndUI(repository)
-                        splitPane.topComponent
+                        if (repository != null) {
+                            toggleLoading()
+                            loadDataAndUI(repository)
+                            toggleLoading()
+                        }
                     }
                 }
             })
@@ -161,22 +171,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
                     val map = extractSarif(github, repositoryFullName, selectedCombo?.head)
                     if (map.isEmpty()) {
-                        val element = Leaf(
-                            leafName = "",
-                            address = "",
-                            steps = listOf(),
-                            location = "",
-                            ruleId = "",
-                            ruleName = "",
-                            ruleDescription = "",
-                            level = "",
-                            kind = "",
-                            githubAlertNumber = "",
-                            githubAlertUrl = "",
-                        )
-                        map["No SARIF file found for the repository $repositoryFullName and ref $sarifGitHubRef"] =
-                            listOf(element).toMutableList()
-                        displayError("No SARIF file found for the repository $repositoryFullName and ref $sarifGitHubRef")
+                        emptyNode(map, repositoryFullName)
                     } else {
                         thisLogger().info("Load result for the repository $repositoryFullName and ref $sarifGitHubRef")
                     }
@@ -193,6 +188,32 @@ class SarifViewerWindowFactory : ToolWindowFactory {
             }
         }
 
+        private fun emptyNode(
+            map: HashMap<String, MutableList<Leaf>>,
+            repositoryFullName: String?
+        ) {
+            val element = Leaf(
+                leafName = "",
+                address = "",
+                steps = listOf(),
+                location = "",
+                ruleId = "",
+                ruleName = "",
+                ruleDescription = "",
+                level = "",
+                kind = "",
+                githubAlertNumber = "",
+                githubAlertUrl = "",
+            )
+            map["No SARIF file found for the repository $repositoryFullName and ref $sarifGitHubRef"] =
+                listOf(element).toMutableList()
+        }
+
+        private fun toggleLoading(forcedValue: Boolean? = null) {
+            loading = forcedValue ?: !loading
+            loadingPanel.isVisible = loading
+        }
+
         private fun displayError(message: String) {
             clearJSplitPane()
             errorToolbar.isVisible = true
@@ -207,6 +228,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
         }
 
         private fun JBPanel<JBPanel<*>>.buildSkeleton() {
+
             infos.isEditable = false
             infos.addHyperlinkListener(object : HyperlinkListener {
                 override fun hyperlinkUpdate(hle: HyperlinkEvent?) {
@@ -251,7 +273,9 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
             comboBranchPR.addActionListener(ActionListener() { event ->
                 val comboBox = event.source as JComboBox<*>
-                if (event.actionCommand == "comboBoxChanged" && comboBox.selectedItem != null) {
+                if (event.actionCommand == "comboBoxChanged" && comboBox.selectedItem != null
+                    && !disableComboBoxEvent && !DumbService.isDumb(project)
+                ) {
                     val selectedOption = comboBox.selectedItem as BranchItemComboBox
                     sarifGitHubRef = if (selectedOption.prNumber != 0) {
                         "refs/pull/${selectedOption.prNumber}/merge"
@@ -262,7 +286,15 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     clearJSplitPane()
                     val repository = GitRepositoryManager.getInstance(project).repositories.firstOrNull()
                     if (repository != null) {
-                        loadDataAndUI(repository, selectedOption)
+                        // Create a SwingWorker to perform the time-consuming task in a separate thread
+                        val worker = object : SwingWorker<Unit, Unit>() {
+                            override fun doInBackground() {
+                                toggleLoading(true)
+                                loadDataAndUI(repository, selectedOption)
+                                toggleLoading(false)
+                            }
+                        }
+                        worker.execute()
                     } else {
                         add(JLabel("No Git repository found"))
                     }
@@ -290,6 +322,12 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
             add(jToolBar)
 
+            loadingPanel.layout = BoxLayout(loadingPanel, BoxLayout.Y_AXIS)
+            loadingPanel.add(JLabel("Loading..."))
+            loadingPanel.add(JLabel("Please wait..."))
+            loadingPanel.isVisible = false
+            add(loadingPanel)
+
             add(splitPane)
 
             details.isVisible = false
@@ -304,15 +342,22 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
             refreshButton.addActionListener(ActionListener() {
                 localMode = false
-                clearJSplitPane()
-                populateCombo(currentBranch, github, repositoryFullName)
-                val mapSarif = extractSarif(github, repositoryFullName)
-                if (mapSarif.isEmpty()) {
-                    displayError("No SARIF file found")
-                } else {
-                    thisLogger().info("Load result for the repository $repositoryFullName and branch ${currentBranch.name}")
-                    buildContent(mapSarif, github, repositoryFullName, currentBranch)
+                val worker = object : SwingWorker<Unit, Unit>() {
+                    override fun doInBackground() {
+                        toggleLoading(true)
+                        clearJSplitPane()
+                        populateCombo(currentBranch, github, repositoryFullName)
+                        val mapSarif = extractSarif(github, repositoryFullName)
+                        toggleLoading(false)
+                        if (mapSarif.isEmpty()) {
+                            emptyNode(mapSarif, repositoryFullName)
+                        } else {
+                            thisLogger().info("Load result for the repository $repositoryFullName and branch ${currentBranch.name}")
+                        }
+                        buildContent(mapSarif, github, repositoryFullName, currentBranch)
+                    }
                 }
+                worker.execute()
             })
 
             treeBuilding(map)
@@ -459,6 +504,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
             github: GitHubInstance,
             repositoryFullName: String
         ) {
+            disableComboBoxEvent = true
             comboBranchPR.removeAllItems()
             comboBranchPR.addItem(BranchItemComboBox(0, currentBranch?.name ?: "main", "", ""))
             val pullRequests =
@@ -477,6 +523,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     )
                 }
             }
+            disableComboBoxEvent = false
         }
     }
 }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -99,9 +99,14 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     if (!localMode) {
                         clearJSplitPane()
                         if (repository != null) {
-                            toggleLoading()
-                            loadDataAndUI(repository)
-                            toggleLoading()
+                            val worker = object : SwingWorker<Unit, Unit>() {
+                                override fun doInBackground() {
+                                    toggleLoading()
+                                    loadDataAndUI(repository)
+                                    toggleLoading()
+                                }
+                            }
+                            worker.execute()
                         }
                     }
                 }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -177,8 +177,8 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     }
                     buildContent(map, github, repositoryFullName, currentBranch)
                 } catch (e: SarifViewerException) {
-                    add(JLabel(e.message))
                     thisLogger().warn(e.message)
+                    displayError(e.message)
                     return
                 }
 


### PR DESCRIPTION
This pull request includes changes to the `SarifViewerWindowFactory.kt` file in the `src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/` directory. The changes mainly focus on improving the handling of loading states, adding a loading panel, and refactoring how errors are displayed. 

Here are the most important changes:

### Loading State Management:

* `import com.intellij.openapi.project.DumbService` has been added to the import statements. This service will allow us to check if the project is in a 'dumb' state (i.e., the IDE is performing background tasks like indexing and certain operations are unavailable) and to run code after the project returns to 'smart' state.
* Two new variables, `loadingPanel` and `loading`, have been added to the `SarifViewerWindowFactory` class to manage the loading state.
* A new method, `toggleLoading()`, has been added to switch the loading state and update the visibility of the loading panel.
* Loading state is toggled before and after `loadDataAndUI(repository)` is called in several places. <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR98-R127">[1]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR294-R302">[2]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR350-R365">[3]</a>
* A loading panel with a "Loading... Please wait..." message has been added to the UI.

### Error Handling:

* The `emptyNode()` method has been introduced to handle cases when no SARIF file is found for a given repository.
* The `displayError()` method is now used to display error messages in the UI.

### Other Changes:

* The `disableComboBoxEvent` variable has been introduced to prevent the comboBox event from triggering when the comboBox items are being populated. <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL254-R283">[1]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR512">[2]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR531">[3]</a>
* The `DumbService.getInstance(project).runWhenSmart {}` method is used to delay certain code execution until after the project indexing is finished.
* SwingWorkers are used to perform time-consuming tasks in a separate thread. <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR98-R127">[1]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR294-R302">[2]</a> <a href="diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR350-R365">[3]</a>