### PR TITLE
refactor actions buttons + add a per file view of vulnerabilities

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/OpenLocalAction.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/OpenLocalAction.kt
@@ -1,0 +1,18 @@
+package com.github.adrienpessu.sarifviewer.actions
+
+import com.github.adrienpessu.sarifviewer.toolWindow.SarifViewerWindowFactory
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class OpenLocalAction : AnAction("Open local Sarif file") {
+
+    var myToolWindow: SarifViewerWindowFactory.MyToolWindow? = null
+        set(value) {
+            field = value
+        }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        myToolWindow?.openLocalFile()
+    }
+}
+

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/RefreshAction.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/RefreshAction.kt
@@ -1,0 +1,22 @@
+package com.github.adrienpessu.sarifviewer.actions
+
+import com.github.adrienpessu.sarifviewer.exception.SarifViewerException
+import com.github.adrienpessu.sarifviewer.toolWindow.SarifViewerWindowFactory
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class RefreshAction : AnAction("Refresh from GitHub") {
+    var myToolWindow: SarifViewerWindowFactory.MyToolWindow? = null
+        set(value) {
+            field = value
+        }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val gitHubInstance = myToolWindow?.github?: throw SarifViewerException.INVALID_REPOSITORY
+        val repositoryFullName = myToolWindow?.repositoryFullName?: throw SarifViewerException.INVALID_REPOSITORY
+        val currentBranch = myToolWindow?.currentBranch?: throw SarifViewerException.INVALID_BRANCH
+
+        myToolWindow?.refresh(currentBranch, gitHubInstance, repositoryFullName)
+    }
+}
+

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/exception/SarifViewerException.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/exception/SarifViewerException.kt
@@ -7,5 +7,6 @@ class SarifViewerException(val code: Int, override val message: String): Excepti
         val INVALID_REPOSITORY = SarifViewerException(4, "Invalid repository or no analyses available")
         val INVALID_BRANCH = SarifViewerException(5, "Invalid branch")
         val INVALID_SARIF = SarifViewerException(7, "Invalid SARIF file")
+        val INVALID_VIEW = SarifViewerException(8, "Invalid view type")
     }
 }

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/models/View.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/models/View.kt
@@ -1,0 +1,15 @@
+package com.github.adrienpessu.sarifviewer.models
+
+data class View(
+    val key: String = "",
+    val value: String = ""
+) {
+    override fun toString() = value
+
+    companion object {
+        val RULE = View("rules", "View by rules")
+        val LOCATION = View("location", "View by location")
+        val views = arrayOf(RULE, LOCATION)
+    }
+}
+

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -305,12 +305,14 @@ class SarifViewerWindowFactory : ToolWindowFactory {
             add(errorToolbar)
 
             val jToolBar = JToolBar("", JToolBar.HORIZONTAL)
-            jToolBar.setSize(100, 10)
             jToolBar.isFloatable = false
             jToolBar.isRollover = true
             jToolBar.alignmentX = Component.LEFT_ALIGNMENT
 
             val viewComboBox = ComboBox(View.views)
+
+            viewComboBox.maximumSize = Dimension(100, 30)
+
             viewComboBox.selectedItem = currentView
 
             viewComboBox.addActionListener(ActionListener() { event ->
@@ -343,7 +345,10 @@ class SarifViewerWindowFactory : ToolWindowFactory {
             })
             jToolBar.add(viewComboBox)
 
-            jToolBar.add(JLabel("Branch/PR: "))
+            val jLabel = JLabel("Branch/PR: ")
+            jLabel.maximumSize = Dimension(100, jToolBar.preferredSize.height)
+
+            jToolBar.add(jLabel)
 
             comboBranchPR.addActionListener(ActionListener() { event ->
                 val comboBox = event.source as JComboBox<*>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,15 @@
 
     <resource-bundle>messages.MyBundle</resource-bundle>
 
+    <actions>
+        <action id="OpenLocalFileAction" icon="AllIcons.Actions.MenuOpen" class="com.github.adrienpessu.sarifviewer.actions.OpenLocalAction" text="Open local SARIF file">
+        </action>
+        <action id="RefreshAction" icon="AllIcons.Actions.ForceRefresh" class="com.github.adrienpessu.sarifviewer.actions.RefreshAction" text="Refresh from GitHub">
+        </action>
+    </actions>
+
+
+
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="com.github.adrienpessu.sarifviewer.toolWindow.SarifViewerWindowFactory" id="Sarif viewer"/>
         <applicationConfigurable


### PR DESCRIPTION
This pull request introduces significant changes to the `sarifviewer` package to enhance the tool's functionality and streamline its codebase. The major modifications include the addition of two new actions `OpenLocalAction` and `RefreshAction`, refactoring of the `SarifViewerWindowFactory` class to accommodate these new actions, and updates to the plugin configuration file.

New Actions:

* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/OpenLocalAction.kt`](diffhunk://#diff-0cef9236f906dfa88e09053f447d9775c19ee8181021ed0faccac84b35128b77R1-R18): A new action `OpenLocalAction` has been added which allows users to open a local Sarif file.
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/RefreshAction.kt`](diffhunk://#diff-e534412080cf64322a910e50785cad4a440df1e84c44d7e73f4343d27de18fd6R1-R22): Another new action `RefreshAction` has been created which enables users to refresh data from GitHub.

Updates to `SarifViewerWindowFactory`:

* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR6-R7): The `SarifViewerWindowFactory` class has been significantly refactored to integrate the new actions. This includes the addition of `OpenLocalAction` and `RefreshAction` to the tool window's title actions, removal of the `refreshButton` and `localFileButton`, and relocation of their functionalities to the respective new actions. Also, the `buildContent` method has been simplified, and several variables (`github`, `repositoryFullName`, `currentBranch`) have been moved to class-level scope for accessibility across different methods. [[1]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR6-R7) [[2]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR18-R19) [[3]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR33) [[4]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL41) [[5]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR74-R104) [[6]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL85) [[7]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL121-L124) [[8]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL143-R185) [[9]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL172-R212) [[10]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL282) [[11]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL315-L332) [[12]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL347-R372) [[13]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL367-L373)

Plugin Configuration:

* [`src/main/resources/META-INF/plugin.xml`](diffhunk://#diff-13198d14dd3abf13abd9cb906331ed7d9663fc081757b6845fd5f3c1850b5693R12-R20): The plugin configuration file has been updated to include the two new actions `OpenLocalFileAction` and `RefreshAction`.