### PR TITLE
small error fixes + prepare for the release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.adrienpessu.sarifviewer
 pluginName = SARIF-viewer
 pluginRepositoryUrl = https://github.com/adrienpessu/SARIF-viewer
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.0
+pluginVersion = 1.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -403,12 +403,14 @@ class SarifViewerWindowFactory : ToolWindowFactory {
         fun openLocalFile() {
             val fileChooser = JFileChooser()
             fileChooser.fileFilter = FileNameExtensionFilter("SARIF files", "sarif")
-            val returnValue = fileChooser.showOpenDialog(null)
-            if (returnValue == JFileChooser.APPROVE_OPTION) {
-                val selectedFile: File = fileChooser.selectedFile
-                val extractSarifFromFile = extractSarifFromFile(selectedFile)
-                treeBuilding(extractSarifFromFile)
-                localMode = true
+            SwingUtilities.invokeLater {
+                val returnValue = fileChooser.showOpenDialog(null)
+                if (returnValue == JFileChooser.APPROVE_OPTION) {
+                    val selectedFile: File = fileChooser.selectedFile
+                    val extractSarifFromFile = extractSarifFromFile(selectedFile)
+                    treeBuilding(extractSarifFromFile)
+                    localMode = true
+                }
             }
         }
 
@@ -565,8 +567,10 @@ class SarifViewerWindowFactory : ToolWindowFactory {
 
         private fun clearJSplitPane() {
             if (myList.components != null) {
-                myList.model = DefaultTreeModel(DefaultMutableTreeNode())
-                myList.updateUI()
+                SwingUtilities.invokeLater {
+                    myList.model = DefaultTreeModel(DefaultMutableTreeNode())
+                    myList.updateUI()
+                }
             }
 
             infos.text = ""


### PR DESCRIPTION
This pull request includes updates to the SARIF-viewer plugin and improvements to the user interface handling in the `SarifViewerWindowFactory.kt` file. The plugin version has been updated, and SwingUtilities.invokeLater has been added in several places to ensure that UI updates are made on the Event Dispatch Thread (EDT).

Here are the most important changes:

Plugin version update:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L7-R7): The plugin version has been updated from 1.0.0 to 1.1.0. This indicates that there have been backward-compatible additions to the functionality.

UI handling improvements:
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR406): Added `SwingUtilities.invokeLater` to ensure that the file chooser dialog is opened on the EDT. This is important to prevent potential threading issues with Swing components. [[1]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR406) [[2]](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR415)
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daR570-R574): Added `SwingUtilities.invokeLater` to ensure that the UI updates are made on the EDT when clearing the JSplitPane. Again, this is to prevent potential threading issues with Swing components.